### PR TITLE
Fix 404 Error in Profile Update Controller

### DIFF
--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -11,7 +11,8 @@ const authenticationMiddleware = async (req, res, next) => {
 
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = { userId: payload.userId, parentName: payload.parentName }
+    req.user = { userId: payload.userId, parentName: payload.parentName };
+    console.log('Authenticated user:', req.user);
   } catch {
     throw new UnauthenticatedError('Authentication invalid');
   };

--- a/src/models/usersModel.js
+++ b/src/models/usersModel.js
@@ -81,7 +81,11 @@ userSchema.pre('save', async function (next) {
 
 userSchema.methods.generateAuthToken = function () {
     const token = jwt.sign(
-        { userId: this._id, email: this.email },
+      {
+        userId: this._id,
+        email: this.email,
+        parentName: this.parentName
+      },
         process.env.JWT_SECRET,
         { expiresIn: process.env.JWT_LIFETIME }
     );


### PR DESCRIPTION
This pull request fixes a bug in the user profile update functionality that was causing a 404 error when attempting to update a user profile. I fixed the bug by including `parentName` in the JWT token.  I manually tested the profile update functionality using Postman to confirm that profiles are now correctly updated without encountering a 404 error.